### PR TITLE
Refactor connection file, abstract JupyterKernel to start evcxr or ipython

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,7 +70,7 @@ jobs:
           uses: actions-rust-lang/setup-rust-toolchain@v1
           with:
             toolchain: 'nightly'
-            components: rustfmt
+            components: rustfmt,clippy
 
         - name: Check code format
           run: cargo fmt -- --check

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,6 +44,14 @@ jobs:
           toolchain-version: '1.74.0'
           profile: minimal
 
+      # Cache Evcxr installation
+      - name: Cache Evcxr installation
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/bin
+          key: ${{ runner.os }}-evcxr-${{ hashFiles('**/Cargo.lock') }}
+
       - name: Install evcxr-jupyter
         run: |
           cargo install evcxr_jupyter

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Rust 1.74.0
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain-version: '1.74.0'
+          toolchain: '1.74.0'
           profile: minimal
 
       - name: Run tests
@@ -41,15 +41,14 @@ jobs:
       - name: Set up Rust 1.74.0
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain-version: '1.74.0'
+          toolchain: '1.74.0'
           profile: minimal
 
       # Cache Evcxr installation
       - name: Cache Evcxr installation
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
-          path: |
-            ~/.cargo/bin
+          path: ~/.cargo/bin
           key: ${{ runner.os }}-evcxr-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install evcxr-jupyter
@@ -70,7 +69,7 @@ jobs:
         - name: Set up Rust Nightly
           uses: actions-rust-lang/setup-rust-toolchain@v1
           with:
-            toolchain-version: 'nightly'
+            toolchain: 'nightly'
             components: rustfmt
 
         - name: Check code format

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
+  test-ipython:
     runs-on: ubuntu-latest
 
     steps:
@@ -30,9 +30,27 @@ jobs:
           profile: minimal
 
       - name: Run tests
-        run: cargo test
-        env:
-          CI: true # tells our test suite to use externally started kernel instead of starting itself
+        run: cargo test --test test_ipython
+
+  test-evcxr:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Rust 1.74.0
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain-version: '1.74.0'
+          profile: minimal
+
+      - name: Install evcxr-jupyter
+        run: |
+          cargo install evcxr_jupyter
+          evcxr_jupyter --install
+
+      - name: Run tests
+        run: cargo test --test test_evcxr
 
 
   lint:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ bytes = { version = "1.5.0", features = ["serde"] }
 chrono = { version = "0.4.31", features = ["serde"] }
 hex = "0.4.3"
 lazy_static = "1.4.0"
+rand = "0.8.5"
 ring = "0.17.5"
 serde = { version = "1.0.190", features = ["derive"] }
 serde_json = "1.0.108"

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Roadmap:
  - [x] Implement the Action and message delegation concepts from Python version
  - [ ] Model all Jupyter messages
  - [ ] Model in-memory Notebook and create utility handlers for updating it based on outputs
+ - [x] Test multiple Kernel backends (IPython, Rust evcxr, etc)
  - [ ] Implement CLI similar to Python kernel-sidecar
  - [ ] Create example app of controlling Notebooks from external calls, e.g. AI function calling
  - [ ] Create example of integration with Carabiner GPT

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -6,14 +6,10 @@ use std::task::{Context, Poll, Waker};
 
 use tokio::sync::{mpsc, Mutex};
 
+use crate::handlers::Handler;
 use crate::jupyter::message_content::status::KernelStatus;
 use crate::jupyter::request::Request;
 use crate::jupyter::response::Response;
-
-#[async_trait::async_trait]
-pub trait Handler: Debug + Send + Sync {
-    async fn handle(&self, msg: &Response);
-}
 
 #[derive(Debug, PartialEq)]
 pub enum ExpectedReplyType {

--- a/src/client.rs
+++ b/src/client.rs
@@ -35,25 +35,22 @@ let action = client.kernel_info_request(handlers).await;
 action.await;
 */
 
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::error::Error;
-use std::fs;
-use std::net::IpAddr;
-use std::path::Path;
+
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{mpsc, Notify, RwLock};
 use tokio::time::sleep;
 use zeromq::{DealerSocket, ReqSocket, Socket, SocketRecv, SocketSend, SubSocket, ZmqMessage};
 
+use crate::actions::Action;
 use crate::handlers::Handler;
+use crate::jupyter::connection_file::ConnectionInfo;
 use crate::jupyter::message_content::execute::ExecuteRequest;
 use crate::jupyter::message_content::kernel_info::KernelInfoRequest;
 use crate::jupyter::request::Request;
 use crate::jupyter::response::Response;
 use crate::jupyter::wire_protocol::WireProtocol;
-use crate::{actions::Action, jupyter::connection_file::ConnectionInfo};
 
 #[derive(Debug, Clone)]
 pub struct Client {

--- a/src/client.rs
+++ b/src/client.rs
@@ -47,42 +47,13 @@ use tokio::sync::{mpsc, Notify, RwLock};
 use tokio::time::sleep;
 use zeromq::{DealerSocket, ReqSocket, Socket, SocketRecv, SocketSend, SubSocket, ZmqMessage};
 
-use crate::actions::{Action, Handler};
+use crate::handlers::Handler;
 use crate::jupyter::message_content::execute::ExecuteRequest;
 use crate::jupyter::message_content::kernel_info::KernelInfoRequest;
 use crate::jupyter::request::Request;
 use crate::jupyter::response::Response;
 use crate::jupyter::wire_protocol::WireProtocol;
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct ConnectionInfo {
-    ip: IpAddr,
-    transport: String,
-    iopub_port: u16,
-    shell_port: u16,
-    hb_port: u16,
-    key: String, // hmac signing key
-}
-
-impl ConnectionInfo {
-    pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Self, Box<dyn Error>> {
-        let file_contents = fs::read_to_string(path)?;
-        let connection_info: Self = serde_json::from_str(&file_contents)?;
-        Ok(connection_info)
-    }
-
-    pub fn iopub_address(&self) -> String {
-        format!("{}://{}:{}", self.transport, self.ip, self.iopub_port)
-    }
-
-    pub fn shell_address(&self) -> String {
-        format!("{}://{}:{}", self.transport, self.ip, self.shell_port)
-    }
-
-    pub fn heartbeat_address(&self) -> String {
-        format!("{}://{}:{}", self.transport, self.ip, self.hb_port)
-    }
-}
+use crate::{actions::Action, jupyter::connection_file::ConnectionInfo};
 
 #[derive(Debug, Clone)]
 pub struct Client {

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -1,7 +1,9 @@
 use tokio::sync::Mutex;
 
 use crate::jupyter::response::Response;
-use std::{collections::HashMap, fmt::Debug, sync::Arc};
+use std::collections::HashMap;
+use std::fmt::Debug;
+use std::sync::Arc;
 
 #[async_trait::async_trait]
 pub trait Handler: Debug + Send + Sync {
@@ -11,6 +13,12 @@ pub trait Handler: Debug + Send + Sync {
 // dbg!'s all messages handled by an Action
 #[derive(Debug)]
 pub struct DebugHandler;
+
+impl Default for DebugHandler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 impl DebugHandler {
     pub fn new() -> Self {
@@ -29,6 +37,12 @@ impl Handler for DebugHandler {
 #[derive(Debug, Clone)]
 pub struct MessageCountHandler {
     pub counts: Arc<Mutex<HashMap<String, usize>>>,
+}
+
+impl Default for MessageCountHandler {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl MessageCountHandler {

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -1,0 +1,50 @@
+use tokio::sync::Mutex;
+
+use crate::jupyter::response::Response;
+use std::{collections::HashMap, fmt::Debug, sync::Arc};
+
+#[async_trait::async_trait]
+pub trait Handler: Debug + Send + Sync {
+    async fn handle(&self, msg: &Response);
+}
+
+// dbg!'s all messages handled by an Action
+#[derive(Debug)]
+pub struct DebugHandler;
+
+impl DebugHandler {
+    pub fn new() -> Self {
+        DebugHandler {}
+    }
+}
+
+#[async_trait::async_trait]
+impl Handler for DebugHandler {
+    async fn handle(&self, msg: &Response) {
+        dbg!(msg);
+    }
+}
+
+// Returns a hashmap of {msg_type: count} for all messages handled by an Action
+#[derive(Debug, Clone)]
+pub struct MessageCountHandler {
+    pub counts: Arc<Mutex<HashMap<String, usize>>>,
+}
+
+impl MessageCountHandler {
+    pub fn new() -> Self {
+        MessageCountHandler {
+            counts: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl Handler for MessageCountHandler {
+    async fn handle(&self, msg: &Response) {
+        let mut counts = self.counts.lock().await;
+        let msg_type = msg.msg_type();
+        let count = counts.entry(msg_type).or_insert(0);
+        *count += 1;
+    }
+}

--- a/src/jupyter/connection_file.rs
+++ b/src/jupyter/connection_file.rs
@@ -1,12 +1,11 @@
-use rand::{distributions::Alphanumeric, Rng};
+use rand::distributions::Alphanumeric;
+use rand::Rng;
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::fs::{self, File};
 use std::io::{self, Write};
 use std::net::TcpListener;
 use std::path::Path;
-use std::{
-    collections::HashSet,
-    fs::{self, File},
-};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ConnectionInfo {

--- a/src/jupyter/connection_file.rs
+++ b/src/jupyter/connection_file.rs
@@ -1,0 +1,100 @@
+use rand::{distributions::Alphanumeric, Rng};
+use serde::{Deserialize, Serialize};
+use std::io::{self, Write};
+use std::net::TcpListener;
+use std::path::Path;
+use std::{
+    collections::HashSet,
+    fs::{self, File},
+};
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ConnectionInfo {
+    ip: String,
+    transport: String,
+    shell_port: u16,
+    iopub_port: u16,
+    stdin_port: u16,
+    control_port: u16,
+    hb_port: u16,
+    signature_scheme: String,
+    pub key: String,
+    kernel_name: Option<String>,
+}
+
+fn find_open_port() -> Result<u16, std::io::Error> {
+    TcpListener::bind("127.0.0.1:0")
+        .and_then(|listener| listener.local_addr())
+        .map(|addr| addr.port())
+}
+
+fn generate_hmac_key() -> String {
+    rand::thread_rng()
+        .sample_iter(&Alphanumeric)
+        .take(32)
+        .map(char::from)
+        .collect()
+}
+
+impl ConnectionInfo {
+    pub fn new(kernel_name: Option<String>) -> Result<Self, io::Error> {
+        let mut ports = HashSet::new();
+        while ports.len() < 5 {
+            let port = find_open_port()?;
+            ports.insert(port);
+        }
+
+        let mut port_iter = ports.into_iter();
+        Ok(Self {
+            ip: "127.0.0.1".to_string(),
+            transport: "tcp".to_string(),
+            shell_port: port_iter.next().unwrap(),
+            iopub_port: port_iter.next().unwrap(),
+            stdin_port: port_iter.next().unwrap(),
+            control_port: port_iter.next().unwrap(),
+            hb_port: port_iter.next().unwrap(),
+            signature_scheme: "hmac-sha256".to_string(),
+            key: generate_hmac_key(),
+            kernel_name,
+        })
+    }
+
+    pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Self, io::Error> {
+        let file_contents = fs::read_to_string(path)?;
+        serde_json::from_str(&file_contents).map_err(io::Error::from)
+    }
+
+    pub fn to_file<P: AsRef<Path>>(&self, path: P) -> Result<(), io::Error> {
+        let json = serde_json::to_string_pretty(self)?;
+        let mut file = File::create(path)?;
+        file.write_all(json.as_bytes())?;
+        Ok(())
+    }
+
+    pub fn to_temp_file(&self) -> Result<std::path::PathBuf, io::Error> {
+        let mut file_path = std::env::temp_dir();
+        if self.kernel_name.is_some() {
+            file_path.push(format!(
+                "kernel-sidecar-{}-{}.json",
+                self.kernel_name.as_ref().unwrap(),
+                uuid::Uuid::new_v4()
+            ));
+        } else {
+            file_path.push(format!("kernel-sidecar-{}.json", uuid::Uuid::new_v4()));
+        }
+        self.to_file(&file_path)?;
+        Ok(file_path)
+    }
+
+    pub fn iopub_address(&self) -> String {
+        format!("{}://{}:{}", self.transport, self.ip, self.iopub_port)
+    }
+
+    pub fn shell_address(&self) -> String {
+        format!("{}://{}:{}", self.transport, self.ip, self.shell_port)
+    }
+
+    pub fn heartbeat_address(&self) -> String {
+        format!("{}://{}:{}", self.transport, self.ip, self.hb_port)
+    }
+}

--- a/src/jupyter/mod.rs
+++ b/src/jupyter/mod.rs
@@ -3,6 +3,7 @@ pub mod message_content;
 pub mod metadata;
 pub mod wire_protocol;
 
+pub mod connection_file;
 pub mod constants;
 pub mod message;
 pub mod request;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod actions;
 pub mod client;
+pub mod handlers;
 pub mod jupyter;
 pub mod utils;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,39 +1,20 @@
-use kernel_sidecar_rs::actions::Handler;
-use kernel_sidecar_rs::client::{Client, ConnectionInfo};
-use kernel_sidecar_rs::jupyter::response::Response;
-use std::fmt::Debug;
+use kernel_sidecar_rs::handlers::{DebugHandler, Handler};
+use kernel_sidecar_rs::utils::JupyterKernel;
+use kernel_sidecar_rs::{client::Client, jupyter::connection_file::ConnectionInfo};
+
 use std::sync::Arc;
-
-#[derive(Debug)]
-struct DebugHandler;
-
-impl DebugHandler {
-    fn new() -> Self {
-        DebugHandler {}
-    }
-}
-
-#[async_trait::async_trait]
-impl Handler for DebugHandler {
-    async fn handle(&self, msg: &Response) {
-        dbg!(msg);
-    }
-}
 
 #[tokio::main]
 async fn main() {
-    // Simple example of running a Sidecar so that it connects to a running kernel,
-    // sends a kernel_info_request, and awaits until it sees the expected kernel_info_reply
-    // in addition to Kernel status going to Idle. Should print out the full parsed ZMQ messages
-    // coming back over iopub and shell channels.
-    let connection_info = ConnectionInfo::from_file("/tmp/kernel.json")
-        .expect("Make sure to run python -m ipykernel_launcher -f /tmp/kernel.json");
-    let client = Client::new(connection_info).await;
+    let kernel = JupyterKernel::evcxr(false);
+    let client = Client::new(kernel.connection_info.clone()).await;
     client.heartbeat().await;
 
     let handler = DebugHandler::new();
     let handlers = vec![Arc::new(handler) as Arc<dyn Handler>];
     // let action = client.kernel_info_request(handlers).await;
-    let action = client.execute_request("2 + 2".to_owned(), handlers).await;
+    let action = client
+        .execute_request("println!(\"hello world\")".to_owned(), handlers)
+        .await;
     action.await;
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
+use kernel_sidecar_rs::client::Client;
 use kernel_sidecar_rs::handlers::{DebugHandler, Handler};
 use kernel_sidecar_rs::utils::JupyterKernel;
-use kernel_sidecar_rs::{client::Client, jupyter::connection_file::ConnectionInfo};
 
 use std::sync::Arc;
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,50 +1,69 @@
+use crate::jupyter::connection_file::ConnectionInfo;
 use std::path::PathBuf;
 use std::process::{Child, Command};
 
 #[derive(Debug)]
-pub struct IPykernel {
+pub struct JupyterKernel {
     process: Child,
+    pub connection_info: ConnectionInfo,
     pub connection_file: PathBuf,
 }
 
-impl IPykernel {
-    // start an ipykernel process. If set to silent, stdout redirects to /dev/null
-    pub fn new(silent: bool) -> Self {
-        // write connection file at /tmp/kernel-sidecar-{uuid}.json
-        let mut file_path = std::env::temp_dir();
-        file_path.push(format!("kernel-sidecar-{}.json", uuid::Uuid::new_v4()));
-        let connection_file = file_path;
-        let process = Command::new("python")
-            .arg("-m")
-            .arg("ipykernel_launcher")
-            .arg("-f")
-            .arg(&connection_file)
+impl JupyterKernel {
+    fn start_process(cmd: Vec<&str>, silent: bool) -> Child {
+        Command::new(cmd[0])
+            .args(&cmd[1..])
             .stdout(if silent {
                 std::process::Stdio::null()
             } else {
                 std::process::Stdio::inherit()
             })
             .spawn()
-            .expect("Failed to start IPykernel");
-        IPykernel {
+            .expect("Failed to start Jupyter Kernel")
+    }
+
+    // start an ipykernel process. If set to silent, stdout redirects to /dev/null
+    pub fn ipython(silent: bool) -> Self {
+        let kernel_name = "ipykernel".to_string();
+        let connection_info = ConnectionInfo::new(Some(kernel_name)).unwrap();
+        let file_path = connection_info.to_temp_file().unwrap();
+        let cmd = vec![
+            "python",
+            "-m",
+            "ipykernel_launcher",
+            "-f",
+            file_path.to_str().unwrap(),
+        ];
+        let process = Self::start_process(cmd, silent);
+        Self {
             process,
-            connection_file,
+            connection_info,
+            connection_file: file_path,
         }
     }
 
-    pub async fn wait_for_file(&self) {
-        loop {
-            if self.connection_file.exists() {
-                break;
-            }
-            tokio::time::sleep(tokio::time::Duration::from_millis(20)).await;
+    // start a Rust (evcxr) kernel.
+    pub fn evcxr(silent: bool) -> Self {
+        let kernel_name = "evcxr".to_string();
+        let connection_info = ConnectionInfo::new(Some(kernel_name)).unwrap();
+        let file_path = connection_info.to_temp_file().unwrap();
+        let cmd = vec![
+            "evcxr_jupyter",
+            "--control_file",
+            file_path.to_str().unwrap(),
+        ];
+        let process = Self::start_process(cmd, silent);
+        Self {
+            process,
+            connection_info,
+            connection_file: file_path,
         }
     }
 }
 
-impl Drop for IPykernel {
+impl Drop for JupyterKernel {
     fn drop(&mut self) {
-        self.process.kill().expect("Failed to kill IPykernel");
+        self.process.kill().expect("Failed to kill Kernel process");
         self.connection_file
             .as_path()
             .to_owned()

--- a/tests/test_evcxr.rs
+++ b/tests/test_evcxr.rs
@@ -11,6 +11,10 @@ async fn start_evcxr() -> (JupyterKernel, Client) {
     let kernel = JupyterKernel::evcxr(true); // true / false is for silencing stdout
     let client = Client::new(kernel.connection_info.clone()).await;
     client.heartbeat().await;
+    // Anecdotally, tests pass fine on local but fail on CI where it's missing status and
+    // execute_input, whicih both come out over iopub. Similar to the ipython tests, seems like
+    // heartbeat and shell are spinning up faster than iopub and we're missing messages there?
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
     (kernel, client)
 }
 

--- a/tests/test_evcxr.rs
+++ b/tests/test_evcxr.rs
@@ -1,0 +1,54 @@
+use std::collections::HashMap;
+
+use std::sync::Arc;
+
+use kernel_sidecar_rs::client::Client;
+use kernel_sidecar_rs::handlers::{Handler, MessageCountHandler};
+use kernel_sidecar_rs::utils::JupyterKernel;
+
+async fn start_evcxr() -> (JupyterKernel, Client) {
+    // Start Kernel, wait for connection file to be written, and wait for ZMQ channels to come up
+    let kernel = JupyterKernel::evcxr(true); // true / false is for silencing stdout
+    let client = Client::new(kernel.connection_info.clone()).await;
+    client.heartbeat().await;
+    (kernel, client)
+}
+
+#[tokio::test]
+async fn test_kernel_info() {
+    let (_kernel, client) = start_evcxr().await;
+
+    // send kernel_info_request
+    let handler = MessageCountHandler::new();
+    let handlers = vec![Arc::new(handler.clone()) as Arc<dyn Handler>];
+    let action = client.kernel_info_request(handlers).await;
+    action.await;
+    let counts = handler.counts.lock().await;
+    let mut expected = HashMap::new();
+    expected.insert("kernel_info_reply".to_string(), 1);
+    expected.insert("status".to_string(), 2);
+    assert_eq!(*counts, expected);
+}
+
+#[tokio::test]
+async fn test_execute_request() {
+    let (_kernel, client) = start_evcxr().await;
+
+    // send execute_request
+    let handler = MessageCountHandler::new();
+    let handlers = vec![Arc::new(handler.clone()) as Arc<dyn Handler>];
+    let action = client
+        .execute_request("println!(\"hello world\")".to_string(), handlers)
+        .await;
+    action.await;
+    let counts = handler.counts.lock().await;
+    let mut expected = HashMap::new();
+    // status busy -> execute_input -> stream -> status idle & execute_reply
+    // evcxr throws in an extra execute_result that ipython doesn't with a print statement
+    expected.insert("status".to_string(), 2);
+    expected.insert("execute_input".to_string(), 1);
+    expected.insert("stream".to_string(), 1);
+    expected.insert("execute_result".to_string(), 1);
+    expected.insert("execute_reply".to_string(), 1);
+    assert_eq!(*counts, expected);
+}

--- a/tests/test_ipython.rs
+++ b/tests/test_ipython.rs
@@ -2,9 +2,9 @@ use std::collections::HashMap;
 
 use std::sync::Arc;
 
+use kernel_sidecar_rs::client::Client;
 use kernel_sidecar_rs::handlers::{Handler, MessageCountHandler};
 use kernel_sidecar_rs::utils::JupyterKernel;
-use kernel_sidecar_rs::{client::Client, handlers::DebugHandler};
 
 async fn start_ipykernel() -> (JupyterKernel, Client) {
     // Start Kernel, wait for connection file to be written, and wait for ZMQ channels to come up


### PR DESCRIPTION
Refactor connection file, abstract JupyterKernel to start evcxr or ipython

clippy+fmt

split CI tests into ipython and evcxr