### PR TITLE
refactor handlers to directory structure

### DIFF
--- a/src/handlers/debug.rs
+++ b/src/handlers/debug.rs
@@ -1,0 +1,26 @@
+use crate::handlers::Handler;
+use crate::jupyter::response::Response;
+
+// dbg!'s all messages handled by an Action
+// Primarily used in introspective click-testing
+#[derive(Debug)]
+pub struct DebugHandler;
+
+impl Default for DebugHandler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DebugHandler {
+    pub fn new() -> Self {
+        DebugHandler {}
+    }
+}
+
+#[async_trait::async_trait]
+impl Handler for DebugHandler {
+    async fn handle(&self, msg: &Response) {
+        dbg!(msg);
+    }
+}

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -1,0 +1,14 @@
+use crate::jupyter::response::Response;
+use std::fmt::Debug;
+
+pub mod debug;
+pub mod msg_count;
+
+// export Handlers
+pub use debug::DebugHandler;
+pub use msg_count::MessageCountHandler;
+
+#[async_trait::async_trait]
+pub trait Handler: Debug + Send + Sync {
+    async fn handle(&self, msg: &Response);
+}

--- a/src/handlers/msg_count.rs
+++ b/src/handlers/msg_count.rs
@@ -1,39 +1,13 @@
+use std::{collections::HashMap, sync::Arc};
+
 use tokio::sync::Mutex;
 
 use crate::jupyter::response::Response;
-use std::collections::HashMap;
-use std::fmt::Debug;
-use std::sync::Arc;
 
-#[async_trait::async_trait]
-pub trait Handler: Debug + Send + Sync {
-    async fn handle(&self, msg: &Response);
-}
-
-// dbg!'s all messages handled by an Action
-#[derive(Debug)]
-pub struct DebugHandler;
-
-impl Default for DebugHandler {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl DebugHandler {
-    pub fn new() -> Self {
-        DebugHandler {}
-    }
-}
-
-#[async_trait::async_trait]
-impl Handler for DebugHandler {
-    async fn handle(&self, msg: &Response) {
-        dbg!(msg);
-    }
-}
+use crate::handlers::Handler;
 
 // Returns a hashmap of {msg_type: count} for all messages handled by an Action
+// Primarily used in tests and introspective click-testing
 #[derive(Debug, Clone)]
 pub struct MessageCountHandler {
     pub counts: Arc<Mutex<HashMap<String, usize>>>,

--- a/src/handlers/msg_count.rs
+++ b/src/handlers/msg_count.rs
@@ -1,4 +1,5 @@
-use std::{collections::HashMap, sync::Arc};
+use std::collections::HashMap;
+use std::sync::Arc;
 
 use tokio::sync::Mutex;
 


### PR DESCRIPTION
Breaking up `handlers.rs` file into a `handlers/` directory in anticipation of adding some more handlers (specifically Output handling)