### PR TITLE
initial hacking towards an OutputHandler

### DIFF
--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -3,10 +3,12 @@ use std::fmt::Debug;
 
 pub mod debug;
 pub mod msg_count;
+pub mod outputs;
 
 // export Handlers
 pub use debug::DebugHandler;
 pub use msg_count::MessageCountHandler;
+pub use outputs::OutputHandler;
 
 #[async_trait::async_trait]
 pub trait Handler: Debug + Send + Sync {

--- a/src/handlers/outputs.rs
+++ b/src/handlers/outputs.rs
@@ -1,0 +1,27 @@
+use crate::{handlers::Handler, jupyter::response::Response};
+use std::collections::HashMap;
+use std::fmt::Debug;
+
+#[async_trait::async_trait]
+pub trait OutputHandler: Handler + Debug + Send + Sync {
+    async fn add_cell_content(&self, content: &HashMap<String, serde_json::Value>);
+    async fn clear_cell_content(&self);
+
+    async fn handle_output(&self, msg: &Response) {
+        match msg {
+            Response::ExecuteResult(result) => {
+                self.add_cell_content(&result.content.data).await;
+            }
+            _ => {}
+        }
+    }
+}
+
+// Need this here so that structs can impl OutputHandler and not get yelled
+// at about also needing to impl Handler
+#[async_trait::async_trait]
+impl<T: OutputHandler + Send + Sync> Handler for T {
+    async fn handle(&self, msg: &Response) {
+        self.handle_output(msg).await;
+    }
+}

--- a/src/handlers/outputs.rs
+++ b/src/handlers/outputs.rs
@@ -1,4 +1,5 @@
-use crate::{handlers::Handler, jupyter::response::Response};
+use crate::handlers::Handler;
+use crate::jupyter::response::Response;
 use std::collections::HashMap;
 use std::fmt::Debug;
 

--- a/src/handlers/outputs.rs
+++ b/src/handlers/outputs.rs
@@ -8,6 +8,7 @@ pub trait OutputHandler: Handler + Debug + Send + Sync {
     async fn add_cell_content(&self, content: &HashMap<String, serde_json::Value>);
     async fn clear_cell_content(&self);
 
+    #[allow(clippy::single_match)]
     async fn handle_output(&self, msg: &Response) {
         match msg {
             Response::ExecuteResult(result) => {

--- a/src/jupyter/iopub_content/execute_result.rs
+++ b/src/jupyter/iopub_content/execute_result.rs
@@ -11,7 +11,7 @@ use serde::Deserialize;
 #[derive(Deserialize, Debug)]
 pub struct ExecuteResult {
     execution_count: u32,
-    data: HashMap<String, serde_json::Value>,
+    pub data: HashMap<String, serde_json::Value>,
     metadata: serde_json::Value,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,8 +8,24 @@ use tokio::signal::unix::{signal, SignalKind};
 use tokio::time::sleep;
 
 use indoc::indoc;
-use std::sync::Arc;
 use std::time::Duration;
+use std::{collections::HashMap, sync::Arc};
+
+use kernel_sidecar_rs::handlers::OutputHandler;
+
+#[derive(Debug)]
+struct DebugOutputHandler {}
+
+#[async_trait::async_trait]
+impl OutputHandler for DebugOutputHandler {
+    async fn add_cell_content(&self, content: &HashMap<String, serde_json::Value>) {
+        println!("add_cell_content: {:?}", content);
+    }
+
+    async fn clear_cell_content(&self) {
+        println!("clear_cell_content");
+    }
+}
 
 #[tokio::main]
 async fn main() {
@@ -25,6 +41,7 @@ async fn main() {
     let handlers = vec![
         Arc::new(debug_handler) as Arc<dyn Handler>,
         Arc::new(msg_count_handler.clone()) as Arc<dyn Handler>,
+        Arc::new(DebugOutputHandler {}) as Arc<dyn Handler>,
     ];
     // let action = client.kernel_info_request(handlers).await;
     let code = indoc! {"2 + 2"};

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,8 +8,9 @@ use tokio::signal::unix::{signal, SignalKind};
 use tokio::time::sleep;
 
 use indoc::indoc;
+use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::Duration;
-use std::{collections::HashMap, sync::Arc};
 
 use kernel_sidecar_rs::handlers::OutputHandler;
 


### PR DESCRIPTION
`cargo run` should print out the string `add_cell_content: {"text/plain": String("4")}` in addition to the other output from Debug Handler and Message Count Handler.

 - Is bubbling up a dictionary of `{mimetype: content}` what we want for adding to cell content?
 - Python version of this basically did the same thing, pushing up `content` -- where `content.data` was the dictionary of mimetype / raw content https://github.com/kafonek/kernel-sidecar/blob/main/src/kernel_sidecar/handlers/output.py#L41