### PR TITLE
Add clear output to OutputHandler

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 async-trait = "0.1.74"
 bytes = { version = "1.5.0", features = ["serde"] }
 chrono = { version = "0.4.31", features = ["serde"] }
+enum-as-inner = "0.6.0"
 hex = "0.4.3"
 indoc = "2.0.4"
 lazy_static = "1.4.0"

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -8,7 +8,7 @@ pub mod outputs;
 // export Handlers
 pub use debug::DebugHandler;
 pub use msg_count::MessageCountHandler;
-pub use outputs::OutputHandler;
+pub use outputs::SimpleOutputHandler;
 
 #[async_trait::async_trait]
 pub trait Handler: Debug + Send + Sync {

--- a/src/handlers/outputs.rs
+++ b/src/handlers/outputs.rs
@@ -19,6 +19,14 @@ pub trait OutputHandler: Handler + Debug + Send + Sync {
                 let output = Output::Stream(m.content.clone());
                 self.add_cell_content(output).await;
             }
+            Response::DisplayData(m) => {
+                let output = Output::DisplayData(m.content.clone());
+                self.add_cell_content(output).await;
+            }
+            Response::Error(m) => {
+                let output = Output::Error(m.content.clone());
+                self.add_cell_content(output).await;
+            }
             Response::ClearOutput(_m) => {
                 self.clear_cell_content().await;
             }

--- a/src/handlers/outputs.rs
+++ b/src/handlers/outputs.rs
@@ -16,6 +16,12 @@ pub struct SimpleOutputHandler {
     pub output: Arc<RwLock<Vec<Output>>>,
 }
 
+impl Default for SimpleOutputHandler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl SimpleOutputHandler {
     pub fn new() -> Self {
         Self {

--- a/src/handlers/outputs.rs
+++ b/src/handlers/outputs.rs
@@ -1,4 +1,4 @@
-use tokio::sync::RwLock;
+use tokio::sync::{Mutex, RwLock};
 
 use crate::handlers::Handler;
 use crate::jupyter::response::Response;
@@ -7,69 +7,23 @@ use crate::notebook::Output;
 use std::fmt::Debug;
 use std::sync::Arc;
 
-#[async_trait::async_trait]
-pub trait OutputHandler: Handler + Debug + Send + Sync {
-    // expect a struct implementing this to have a .clear_on_next_output bool attribute
-    async fn add_cell_content(&self, content: Output);
-    async fn clear_cell_content(&self);
-    async fn sync_display_data(&self, content: Output);
-
-    async fn handle_output(&self, msg: &Response) {
-        match msg {
-            Response::ExecuteResult(m) => {
-                let output = Output::ExecuteResult(m.content.clone());
-                self.add_cell_content(output).await;
-            }
-            Response::Stream(m) => {
-                let output = Output::Stream(m.content.clone());
-                self.add_cell_content(output).await;
-            }
-            Response::DisplayData(m) => {
-                let output = Output::DisplayData(m.content.clone());
-                self.add_cell_content(output).await;
-            }
-            Response::Error(m) => {
-                let output = Output::Error(m.content.clone());
-                self.add_cell_content(output).await;
-            }
-            Response::ClearOutput(_m) => {
-                self.clear_cell_content().await;
-            }
-            _ => {}
-        }
-    }
-}
-
-// Need this here so that structs can impl OutputHandler and not get yelled
-// at about also needing to impl Handler
-#[async_trait::async_trait]
-impl<T: OutputHandler + Send + Sync> Handler for T {
-    async fn handle(&self, msg: &Response) {
-        self.handle_output(msg).await;
-    }
-}
-
 #[derive(Debug, Clone)]
 pub struct SimpleOutputHandler {
+    // interior mutability here because .handle needs to set this and is &self, and when trying
+    // to change that to &mut self then it broke the delegation of ZMQ messages to Actions over
+    // in actions.rs. TODO: come back to this when I'm better at Rust?
+    clear_on_next_output: Arc<Mutex<bool>>,
     pub output: Arc<RwLock<Vec<Output>>>,
-}
-
-impl Default for SimpleOutputHandler {
-    fn default() -> Self {
-        Self::new()
-    }
 }
 
 impl SimpleOutputHandler {
     pub fn new() -> Self {
         Self {
-            output: Arc::new(RwLock::new(Vec::new())),
+            clear_on_next_output: Arc::new(Mutex::new(false)),
+            output: Arc::new(RwLock::new(vec![])),
         }
     }
-}
 
-#[async_trait::async_trait]
-impl OutputHandler for SimpleOutputHandler {
     async fn add_cell_content(&self, content: Output) {
         self.output.write().await.push(content);
         println!("add_cell_content");
@@ -79,10 +33,53 @@ impl OutputHandler for SimpleOutputHandler {
         self.output.write().await.clear();
         println!("clear_cell_content");
     }
+}
 
-    async fn sync_display_data(&self, _content: Output) {
-        // Don't do anything for sync display data in SimpleOutputHandler
-        // we aren't keeping any reference to the full Notebook document in order to
-        // update the display data by id outside of this "current cell" context
+#[async_trait::async_trait]
+impl Handler for SimpleOutputHandler {
+    async fn handle(&self, msg: &Response) {
+        let mut clear_on_next_output = self.clear_on_next_output.lock().await;
+        match msg {
+            Response::ExecuteResult(m) => {
+                let output = Output::ExecuteResult(m.content.clone());
+                if *clear_on_next_output {
+                    self.clear_cell_content().await;
+                    *clear_on_next_output = false;
+                }
+                self.add_cell_content(output).await;
+            }
+            Response::Stream(m) => {
+                let output = Output::Stream(m.content.clone());
+                if *clear_on_next_output {
+                    self.clear_cell_content().await;
+                    *clear_on_next_output = false;
+                }
+                self.add_cell_content(output).await;
+            }
+            Response::DisplayData(m) => {
+                let output = Output::DisplayData(m.content.clone());
+                if *clear_on_next_output {
+                    self.clear_cell_content().await;
+                    *clear_on_next_output = false;
+                }
+                self.add_cell_content(output).await;
+            }
+            Response::Error(m) => {
+                let output = Output::Error(m.content.clone());
+                if *clear_on_next_output {
+                    self.clear_cell_content().await;
+                    *clear_on_next_output = false;
+                }
+                self.add_cell_content(output).await;
+            }
+            Response::ClearOutput(m) => {
+                if m.content.wait {
+                    *clear_on_next_output = true;
+                } else {
+                    self.clear_cell_content().await;
+                }
+            }
+            _ => {}
+        }
     }
 }

--- a/src/handlers/outputs.rs
+++ b/src/handlers/outputs.rs
@@ -84,6 +84,5 @@ impl OutputHandler for SimpleOutputHandler {
         // Don't do anything for sync display data in SimpleOutputHandler
         // we aren't keeping any reference to the full Notebook document in order to
         // update the display data by id outside of this "current cell" context
-        
     }
 }

--- a/src/handlers/outputs.rs
+++ b/src/handlers/outputs.rs
@@ -1,13 +1,17 @@
+use tokio::sync::RwLock;
+
 use crate::handlers::Handler;
 use crate::jupyter::response::Response;
 use crate::notebook::Output;
 
-use std::fmt::Debug;
+use std::{fmt::Debug, sync::Arc};
 
 #[async_trait::async_trait]
 pub trait OutputHandler: Handler + Debug + Send + Sync {
+    // expect a struct implementing this to have a .clear_on_next_output bool attribute
     async fn add_cell_content(&self, content: Output);
     async fn clear_cell_content(&self);
+    async fn sync_display_data(&self, content: Output);
 
     async fn handle_output(&self, msg: &Response) {
         match msg {
@@ -41,5 +45,38 @@ pub trait OutputHandler: Handler + Debug + Send + Sync {
 impl<T: OutputHandler + Send + Sync> Handler for T {
     async fn handle(&self, msg: &Response) {
         self.handle_output(msg).await;
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SimpleOutputHandler {
+    pub output: Arc<RwLock<Vec<Output>>>,
+}
+
+impl SimpleOutputHandler {
+    pub fn new() -> Self {
+        Self {
+            output: Arc::new(RwLock::new(Vec::new())),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl OutputHandler for SimpleOutputHandler {
+    async fn add_cell_content(&self, content: Output) {
+        self.output.write().await.push(content);
+        println!("add_cell_content");
+    }
+
+    async fn clear_cell_content(&self) {
+        self.output.write().await.clear();
+        println!("clear_cell_content");
+    }
+
+    async fn sync_display_data(&self, _content: Output) {
+        // Don't do anything for sync display data in SimpleOutputHandler
+        // we aren't keeping any reference to the full Notebook document in order to
+        // update the display data by id outside of this "current cell" context
+        ()
     }
 }

--- a/src/handlers/outputs.rs
+++ b/src/handlers/outputs.rs
@@ -4,7 +4,8 @@ use crate::handlers::Handler;
 use crate::jupyter::response::Response;
 use crate::notebook::Output;
 
-use std::{fmt::Debug, sync::Arc};
+use std::fmt::Debug;
+use std::sync::Arc;
 
 #[async_trait::async_trait]
 pub trait OutputHandler: Handler + Debug + Send + Sync {
@@ -53,6 +54,12 @@ pub struct SimpleOutputHandler {
     pub output: Arc<RwLock<Vec<Output>>>,
 }
 
+impl Default for SimpleOutputHandler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl SimpleOutputHandler {
     pub fn new() -> Self {
         Self {
@@ -77,6 +84,6 @@ impl OutputHandler for SimpleOutputHandler {
         // Don't do anything for sync display data in SimpleOutputHandler
         // we aren't keeping any reference to the full Notebook document in order to
         // update the display data by id outside of this "current cell" context
-        ()
+        
     }
 }

--- a/src/jupyter/iopub_content/clear_output.rs
+++ b/src/jupyter/iopub_content/clear_output.rs
@@ -6,10 +6,9 @@ use bytes::Bytes;
 
 use serde::Deserialize;
 
-#[allow(dead_code)]
 #[derive(Deserialize, Debug)]
 pub struct ClearOutput {
-    wait: bool,
+    pub wait: bool,
 }
 
 impl From<Bytes> for ClearOutput {

--- a/src/jupyter/iopub_content/display_data.rs
+++ b/src/jupyter/iopub_content/display_data.rs
@@ -4,10 +4,10 @@ https://jupyter-client.readthedocs.io/en/latest/messaging.html#display-data
 use std::collections::HashMap;
 
 use bytes::Bytes;
-use serde::{Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, Serialize};
 
 #[allow(dead_code)]
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug, Serialize, PartialEq)]
 pub struct Transient {
     display_id: String,
 }
@@ -29,7 +29,7 @@ where
 }
 
 #[allow(dead_code)]
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug, Serialize, PartialEq)]
 pub struct DisplayData {
     data: HashMap<String, serde_json::Value>,
     metadata: serde_json::Value,

--- a/src/jupyter/iopub_content/display_data.rs
+++ b/src/jupyter/iopub_content/display_data.rs
@@ -6,10 +6,9 @@ use std::collections::HashMap;
 use bytes::Bytes;
 use serde::{Deserialize, Deserializer, Serialize};
 
-#[allow(dead_code)]
 #[derive(Clone, Deserialize, Debug, Serialize, PartialEq)]
 pub struct Transient {
-    display_id: String,
+    pub display_id: String,
 }
 
 // If the transient field is an empty dict, deserialize it as None
@@ -28,15 +27,14 @@ where
     }
 }
 
-#[allow(dead_code)]
 #[derive(Clone, Deserialize, Debug, Serialize, PartialEq)]
 pub struct DisplayData {
-    data: HashMap<String, serde_json::Value>,
-    metadata: serde_json::Value,
+    pub data: HashMap<String, serde_json::Value>,
+    pub metadata: serde_json::Value,
     // Dev note: serde(default) is important here, when using custom deserialize_with and Option
     // then it will throw errors when the field is missing unless default is included.
     #[serde(default, deserialize_with = "deserialize_transient")]
-    transient: Option<Transient>,
+    pub transient: Option<Transient>,
 }
 
 impl From<Bytes> for DisplayData {
@@ -46,15 +44,14 @@ impl From<Bytes> for DisplayData {
     }
 }
 
-#[allow(dead_code)]
 #[derive(Deserialize, Debug)]
 pub struct UpdateDisplayData {
-    data: HashMap<String, serde_json::Value>,
-    metadata: serde_json::Value,
+    pub data: HashMap<String, serde_json::Value>,
+    pub metadata: serde_json::Value,
     // Dev note: serde(default) is important here, when using custom deserialize_with and Option
     // then it will throw errors when the field is missing unless default is included.
     #[serde(default, deserialize_with = "deserialize_transient")]
-    transient: Option<Transient>,
+    pub transient: Option<Transient>,
 }
 
 impl From<Bytes> for UpdateDisplayData {

--- a/src/jupyter/iopub_content/errors.rs
+++ b/src/jupyter/iopub_content/errors.rs
@@ -3,10 +3,10 @@ https://jupyter-client.readthedocs.io/en/latest/messaging.html#execution-errors
 */
 
 use bytes::Bytes;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 #[allow(dead_code)]
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Serialize, PartialEq, Deserialize, Debug)]
 pub struct Error {
     ename: String,
     evalue: String,

--- a/src/jupyter/iopub_content/errors.rs
+++ b/src/jupyter/iopub_content/errors.rs
@@ -5,12 +5,11 @@ https://jupyter-client.readthedocs.io/en/latest/messaging.html#execution-errors
 use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 
-#[allow(dead_code)]
 #[derive(Clone, Serialize, PartialEq, Deserialize, Debug)]
 pub struct Error {
-    ename: String,
-    evalue: String,
-    traceback: Vec<String>,
+    pub ename: String,
+    pub evalue: String,
+    pub traceback: Vec<String>,
 }
 
 impl From<Bytes> for Error {

--- a/src/jupyter/iopub_content/execute_result.rs
+++ b/src/jupyter/iopub_content/execute_result.rs
@@ -5,14 +5,14 @@ use std::collections::HashMap;
 
 use bytes::Bytes;
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 #[allow(dead_code)]
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Serialize, PartialEq, Deserialize, Debug)]
 pub struct ExecuteResult {
-    execution_count: u32,
+    pub execution_count: u32,
     pub data: HashMap<String, serde_json::Value>,
-    metadata: serde_json::Value,
+    pub metadata: serde_json::Value,
 }
 
 impl From<Bytes> for ExecuteResult {

--- a/src/jupyter/iopub_content/stream.rs
+++ b/src/jupyter/iopub_content/stream.rs
@@ -1,21 +1,23 @@
 /*
 https://jupyter-client.readthedocs.io/en/latest/messaging.html#streams-stdout-stderr-etc
 */
+use crate::notebook::list_or_string_to_string;
 use bytes::Bytes;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Serialize, PartialEq, Deserialize, Debug)]
 #[serde(rename_all = "lowercase")]
-enum StreamName {
+pub enum StreamName {
     Stdout,
     Stderr,
 }
 
 #[allow(dead_code)]
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Serialize, PartialEq, Deserialize, Debug)]
 pub struct Stream {
-    name: StreamName,
-    text: String,
+    pub name: StreamName,
+    #[serde(deserialize_with = "list_or_string_to_string")]
+    pub text: String,
 }
 
 impl From<Bytes> for Stream {

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,38 +8,11 @@ use tokio::signal::unix::{signal, SignalKind};
 use tokio::time::sleep;
 
 use indoc::indoc;
-use kernel_sidecar_rs::notebook::Output;
+
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::RwLock;
 
-use kernel_sidecar_rs::handlers::OutputHandler;
-
-#[derive(Debug, Clone)]
-struct SimpleOutputHandler {
-    pub output: Arc<RwLock<Vec<Output>>>,
-}
-
-impl SimpleOutputHandler {
-    pub fn new() -> Self {
-        Self {
-            output: Arc::new(RwLock::new(Vec::new())),
-        }
-    }
-}
-
-#[async_trait::async_trait]
-impl OutputHandler for SimpleOutputHandler {
-    async fn add_cell_content(&self, content: Output) {
-        self.output.write().await.push(content);
-        println!("add_cell_content");
-    }
-
-    async fn clear_cell_content(&self) {
-        self.output.write().await.clear();
-        println!("clear_cell_content");
-    }
-}
+use kernel_sidecar_rs::handlers::SimpleOutputHandler;
 
 #[tokio::main]
 async fn main() {
@@ -61,7 +34,6 @@ async fn main() {
     // let action = client.kernel_info_request(handlers).await;
     let code = indoc! {r#"
     from IPython.display import clear_output
-    import time
 
 
     print("Before Clear Output")

--- a/src/notebook.rs
+++ b/src/notebook.rs
@@ -2,6 +2,11 @@
 Models a Notebook document. https://ipython.org/ipython-doc/3/notebook/nbformat.html
 */
 
+use crate::jupyter::iopub_content::display_data::DisplayData;
+use crate::jupyter::iopub_content::errors::Error;
+use crate::jupyter::iopub_content::execute_result::ExecuteResult;
+use crate::jupyter::iopub_content::stream::Stream;
+use enum_as_inner::EnumAsInner;
 use serde::{Deserialize, Deserializer, Serialize};
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
@@ -14,26 +19,14 @@ pub struct Notebook {
     pub nbformat_minor: u32,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, EnumAsInner)]
 #[serde(tag = "output_type", rename_all = "snake_case")]
 pub enum Output {
-    // TODO: look into using the content structs from jupyter/iopub_content instead of redefining?
-    DisplayData(serde_json::Value),
-    Stream {
-        name: String,
-        #[serde(deserialize_with = "list_or_string_to_string")]
-        text: String,
-    },
-    ExecuteResult {
-        execution_count: u32,
-        data: serde_json::Value,
-        metadata: serde_json::Value,
-    },
-    Error {
-        ename: String,
-        evalue: String,
-        traceback: Vec<String>,
-    },
+    // TODO: use the content structs from crate::jupyter::iopub_content instead of redefining?
+    DisplayData(DisplayData),
+    Stream(Stream),
+    ExecuteResult(ExecuteResult),
+    Error(Error),
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
@@ -71,7 +64,7 @@ pub struct RawCell {
 }
 
 // Custom deserialization for source field since it may be a Vec<String> or String
-fn list_or_string_to_string<'de, D>(deserializer: D) -> Result<String, D::Error>
+pub fn list_or_string_to_string<'de, D>(deserializer: D) -> Result<String, D::Error>
 where
     D: Deserializer<'de>,
 {

--- a/tests/test_kernels.rs
+++ b/tests/test_kernels.rs
@@ -1,9 +1,7 @@
 use std::sync::Arc;
 
 use kernel_sidecar_rs::client::Client;
-use kernel_sidecar_rs::handlers::OutputHandler;
-use kernel_sidecar_rs::handlers::{Handler, MessageCountHandler};
-use kernel_sidecar_rs::jupyter::iopub_content::stream::StreamName;
+use kernel_sidecar_rs::handlers::{Handler, MessageCountHandler, OutputHandler};
 use kernel_sidecar_rs::kernels::JupyterKernel;
 use kernel_sidecar_rs::notebook::Output;
 use tokio::sync::RwLock;
@@ -81,6 +79,7 @@ struct SimpleOutputHandler {
 }
 
 impl SimpleOutputHandler {
+    #[allow(dead_code)]
     pub fn new() -> Self {
         Self {
             output: Arc::new(RwLock::new(Vec::new())),
@@ -104,7 +103,10 @@ impl OutputHandler for SimpleOutputHandler {
 #[tokio::test]
 #[cfg(feature = "test_ipython")]
 async fn test_clear_output() {
+    // imports only used in this test, makes clippy yell when other tests run
     use indoc::indoc;
+    use kernel_sidecar_rs::jupyter::iopub_content::stream::StreamName;
+
     let (_kernel, client) = start_kernel().await;
 
     // send execute_request

--- a/tests/test_kernels.rs
+++ b/tests/test_kernels.rs
@@ -1,36 +1,9 @@
 use std::sync::Arc;
 
-use kernel_sidecar_rs::client::Client;
-use kernel_sidecar_rs::handlers::{Handler, MessageCountHandler, OutputHandler};
-use kernel_sidecar_rs::kernels::JupyterKernel;
-use kernel_sidecar_rs::notebook::Output;
-use tokio::sync::RwLock;
+use kernel_sidecar_rs::handlers::{Handler, MessageCountHandler};
 
-// Start Kernel (type based on feature flags) and wait for ZMQ channels to come up
-async fn start_kernel() -> (JupyterKernel, Client) {
-    let silent = true;
-    let kernel = if cfg!(feature = "test_ipython") {
-        JupyterKernel::ipython(silent)
-    } else if cfg!(feature = "test_evcxr") {
-        JupyterKernel::evcxr(silent)
-    } else if cfg!(feature = "test_irkernel") {
-        JupyterKernel::irkernel(silent)
-    } else if cfg!(feature = "test_deno") {
-        JupyterKernel::deno(silent)
-    } else {
-        panic!("For tests, choose one feature flag from: test_ipython, test_evcxr, test_irkernel, test_deno")
-    };
-    let client = Client::new(kernel.connection_info.clone()).await;
-    client.heartbeat().await;
-    // Anecdotally, have noticed tests fail becaues Status messages aren't showing up as expected.
-    // Theory is that heartbeat is returning but iopub isn't pushing out messages even though
-    // shell is connected and accepting request / replies?
-    // Could be totally wrong.
-    // Separately, there may be an edge case where multiple JupyterKernel::ipython calls end up
-    // with the same ports and it all blows up. TODO: fix that.
-    tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
-    (kernel, client)
-}
+mod test_utils;
+use test_utils::start_kernel;
 
 #[tokio::test]
 async fn test_kernel_info() {
@@ -69,63 +42,4 @@ async fn test_execute_request() {
     assert_eq!(counts["execute_result"], 1);
     #[cfg(feature = "test_irkernel")]
     assert_eq!(counts["display_data"], 1);
-}
-
-/// Testing outputs
-
-#[derive(Debug, Clone)]
-struct SimpleOutputHandler {
-    pub output: Arc<RwLock<Vec<Output>>>,
-}
-
-impl SimpleOutputHandler {
-    #[allow(dead_code)]
-    pub fn new() -> Self {
-        Self {
-            output: Arc::new(RwLock::new(Vec::new())),
-        }
-    }
-}
-
-#[async_trait::async_trait]
-impl OutputHandler for SimpleOutputHandler {
-    async fn add_cell_content(&self, content: Output) {
-        self.output.write().await.push(content);
-        println!("add_cell_content");
-    }
-
-    async fn clear_cell_content(&self) {
-        self.output.write().await.clear();
-        println!("clear_cell_content");
-    }
-}
-
-#[tokio::test]
-#[cfg(feature = "test_ipython")]
-async fn test_clear_output() {
-    // imports only used in this test, makes clippy yell when other tests run
-    use indoc::indoc;
-    use kernel_sidecar_rs::jupyter::iopub_content::stream::StreamName;
-
-    let (_kernel, client) = start_kernel().await;
-
-    // send execute_request
-    let handler = SimpleOutputHandler::new();
-
-    let handlers = vec![Arc::new(handler.clone()) as Arc<dyn Handler>];
-    let code = indoc! {r#"
-    from IPython.display import clear_output
-    
-    print("Before Clear Output")
-    clear_output()
-    print("After Clear Output")
-    "#}
-    .trim();
-    let action = client.execute_request(code.to_string(), handlers).await;
-    action.await;
-    let final_output = handler.output.read().await;
-    assert_eq!(final_output.len(), 1);
-    let output = &final_output[0].as_stream().unwrap();
-    assert_eq!(output.name, StreamName::Stdout);
-    assert_eq!(output.text, "After Clear Output\n");
 }

--- a/tests/test_notebook.rs
+++ b/tests/test_notebook.rs
@@ -4,7 +4,9 @@ use kernel_sidecar_rs::notebook::Notebook;
 fn test_notebook_structure() {
     // read tests/demo_notebook.ipynb
     let content = std::fs::read_to_string("tests/demo_notebook.ipynb").unwrap();
+
     let nb: Notebook = serde_json::from_str(&content).unwrap();
+    println!("nb: {:?}", nb);
 
     // Serialize the Notebook back to JSON
     let serialized: String = serde_json::to_string(&nb).unwrap();

--- a/tests/test_outputs.rs
+++ b/tests/test_outputs.rs
@@ -1,0 +1,130 @@
+#![cfg(feature = "test_ipython")]
+use indoc::indoc;
+use kernel_sidecar_rs::handlers::{Handler, OutputHandler};
+use kernel_sidecar_rs::jupyter::iopub_content::stream::StreamName;
+use kernel_sidecar_rs::notebook::Output;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+mod test_utils;
+use test_utils::start_kernel;
+
+#[derive(Debug, Clone)]
+struct SimpleOutputHandler {
+    pub output: Arc<RwLock<Vec<Output>>>,
+}
+
+impl SimpleOutputHandler {
+    pub fn new() -> Self {
+        Self {
+            output: Arc::new(RwLock::new(Vec::new())),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl OutputHandler for SimpleOutputHandler {
+    async fn add_cell_content(&self, content: Output) {
+        self.output.write().await.push(content);
+        println!("add_cell_content");
+    }
+
+    async fn clear_cell_content(&self) {
+        self.output.write().await.clear();
+        println!("clear_cell_content");
+    }
+}
+
+#[tokio::test]
+async fn test_mixed_outputs() {
+    // Show that stream and execute result can be mixed
+    let (_kernel, client) = start_kernel().await;
+
+    // send execute_request
+    let handler = SimpleOutputHandler::new();
+
+    let handlers = vec![Arc::new(handler.clone()) as Arc<dyn Handler>];
+    let code = indoc! {r#"
+    print("foo")
+    print("bar")
+    2 + 2
+    "#}
+    .trim();
+    let action = client.execute_request(code.to_string(), handlers).await;
+    action.await;
+    let final_output = handler.output.read().await;
+    assert_eq!(final_output.len(), 2);
+    let stream_output = &final_output[0].as_stream().unwrap();
+    assert_eq!(stream_output.name, StreamName::Stdout);
+    assert_eq!(stream_output.text, "foo\nbar\n");
+    let execute_result = &final_output[1].as_execute_result().unwrap();
+    assert_eq!(execute_result.data["text/plain"], "4");
+}
+
+#[tokio::test]
+async fn test_error_output() {
+    let (_kernel, client) = start_kernel().await;
+
+    // send execute_request
+    let handler = SimpleOutputHandler::new();
+
+    let handlers = vec![Arc::new(handler.clone()) as Arc<dyn Handler>];
+    let code = indoc! {r#"
+    1 / 0
+    "#}
+    .trim();
+    let action = client.execute_request(code.to_string(), handlers).await;
+    action.await;
+    let final_output = handler.output.read().await;
+    assert_eq!(final_output.len(), 1);
+    let error_output = &final_output[0].as_error().unwrap();
+    assert_eq!(error_output.ename, "ZeroDivisionError");
+    assert_eq!(error_output.evalue, "division by zero");
+}
+
+#[tokio::test]
+async fn test_display_data() {
+    let (_kernel, client) = start_kernel().await;
+
+    // send execute_request
+    let handler = SimpleOutputHandler::new();
+
+    let handlers = vec![Arc::new(handler.clone()) as Arc<dyn Handler>];
+    let code = indoc! {r#"
+    from IPython.display import display
+    
+    display("foo")
+    "#}
+    .trim();
+    let action = client.execute_request(code.to_string(), handlers).await;
+    action.await;
+    let final_output = handler.output.read().await;
+    assert_eq!(final_output.len(), 1);
+    let display_data = &final_output[0].as_display_data().unwrap();
+    assert_eq!(display_data.data["text/plain"], "'foo'");
+}
+
+#[tokio::test]
+async fn test_clear_output() {
+    let (_kernel, client) = start_kernel().await;
+
+    // send execute_request
+    let handler = SimpleOutputHandler::new();
+
+    let handlers = vec![Arc::new(handler.clone()) as Arc<dyn Handler>];
+    let code = indoc! {r#"
+    from IPython.display import clear_output
+    
+    print("Before Clear Output")
+    clear_output()
+    print("After Clear Output")
+    "#}
+    .trim();
+    let action = client.execute_request(code.to_string(), handlers).await;
+    action.await;
+    let final_output = handler.output.read().await;
+    assert_eq!(final_output.len(), 1);
+    let output = &final_output[0].as_stream().unwrap();
+    assert_eq!(output.name, StreamName::Stdout);
+    assert_eq!(output.text, "After Clear Output\n");
+}

--- a/tests/test_outputs.rs
+++ b/tests/test_outputs.rs
@@ -1,39 +1,12 @@
 #![cfg(feature = "test_ipython")]
 use indoc::indoc;
-use kernel_sidecar_rs::handlers::{Handler, OutputHandler};
+use kernel_sidecar_rs::handlers::{Handler, SimpleOutputHandler};
 use kernel_sidecar_rs::jupyter::iopub_content::stream::StreamName;
-use kernel_sidecar_rs::notebook::Output;
+
 use std::sync::Arc;
-use tokio::sync::RwLock;
 
 mod test_utils;
 use test_utils::start_kernel;
-
-#[derive(Debug, Clone)]
-struct SimpleOutputHandler {
-    pub output: Arc<RwLock<Vec<Output>>>,
-}
-
-impl SimpleOutputHandler {
-    pub fn new() -> Self {
-        Self {
-            output: Arc::new(RwLock::new(Vec::new())),
-        }
-    }
-}
-
-#[async_trait::async_trait]
-impl OutputHandler for SimpleOutputHandler {
-    async fn add_cell_content(&self, content: Output) {
-        self.output.write().await.push(content);
-        println!("add_cell_content");
-    }
-
-    async fn clear_cell_content(&self) {
-        self.output.write().await.clear();
-        println!("clear_cell_content");
-    }
-}
 
 #[tokio::test]
 async fn test_mixed_outputs() {

--- a/tests/test_utils.rs
+++ b/tests/test_utils.rs
@@ -1,0 +1,28 @@
+use kernel_sidecar_rs::client::Client;
+use kernel_sidecar_rs::kernels::JupyterKernel;
+
+// Start Kernel (type based on feature flags) and wait for ZMQ channels to come up
+pub async fn start_kernel() -> (JupyterKernel, Client) {
+    let silent = true;
+    let kernel = if cfg!(feature = "test_ipython") {
+        JupyterKernel::ipython(silent)
+    } else if cfg!(feature = "test_evcxr") {
+        JupyterKernel::evcxr(silent)
+    } else if cfg!(feature = "test_irkernel") {
+        JupyterKernel::irkernel(silent)
+    } else if cfg!(feature = "test_deno") {
+        JupyterKernel::deno(silent)
+    } else {
+        panic!("For tests, choose one feature flag from: test_ipython, test_evcxr, test_irkernel, test_deno")
+    };
+    let client = Client::new(kernel.connection_info.clone()).await;
+    client.heartbeat().await;
+    // Anecdotally, have noticed tests fail becaues Status messages aren't showing up as expected.
+    // Theory is that heartbeat is returning but iopub isn't pushing out messages even though
+    // shell is connected and accepting request / replies?
+    // Could be totally wrong.
+    // Separately, there may be an edge case where multiple JupyterKernel::ipython calls end up
+    // with the same ports and it all blows up. TODO: fix that.
+    tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+    (kernel, client)
+}


### PR DESCRIPTION
Initial `clear_output` support into the `OutputHandler` trait so that you end up with something like this,

![image](https://github.com/kafonek/kernel-sidecar-rs/assets/3867768/fe144e63-9d33-4b56-8b05-5c49ca03f8d6)
